### PR TITLE
fix: Correct `grammar.repository` type

### DIFF
--- a/tmlanguage.json
+++ b/tmlanguage.json
@@ -31,7 +31,7 @@
             "uuid": { "type": "string" },
             "firstLineMatch": { "type": "string" }
           },
-          "required": ["scopeName"]
+          "required": [ "scopeName" ]
         }
       ]
     },
@@ -47,7 +47,7 @@
             "description": "a dictionary (i.e. key/value pairs) of rules which can be included from other places in the grammar. The key is the name of the rule and the value is the actual rule. Further explanation (and example) follow with the description of the include rule key.",
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/definitions/grammar"
+              "$ref": "#/definitions/pattern"
             }
           }
         },
@@ -121,8 +121,8 @@
           "default": [ ]
         },
         "applyEndPatternLast": {
-          "type": "integer", 
-          "minimum": 0, 
+          "type": "integer",
+          "minimum": 0,
           "maximum": 1
         },
         "while": {
@@ -130,13 +130,13 @@
         }
       },
       "dependencies": {
-        "begin": ["end"],
-        "end": ["begin"],
-        "contentName": ["begin","end"],
-        "beginCaptures": ["begin","end"],
-        "endCaptures": ["begin","end"],
-        "patterns": ["begin","end"],
-        "applyEndPatternLast": ["end"]
+        "begin": [ "end" ],
+        "end": [ "begin" ],
+        "contentName": [ "begin", "end" ],
+        "beginCaptures": [ "begin", "end" ],
+        "endCaptures": [ "begin", "end" ],
+        "patterns": [ "begin", "end" ],
+        "applyEndPatternLast": [ "end" ]
       }
     },
     "name": {


### PR DESCRIPTION
This corrects the type of `grammar.repository`, which is `pattern` and not `grammar`.

Also applies some JSON formatting.

---

review?(@martinring)

**P.S.:** To hide white‑space only changes, append `?w=1` to the end of the URL, like so: https://github.com/martinring/tmlanguage/pull/2/files?w=1