### PR TITLE
Disallow additional props in pattern definition

### DIFF
--- a/tmlanguage.json
+++ b/tmlanguage.json
@@ -129,6 +129,7 @@
           "type": "string"
         }
       },
+      "additionalProperties": false,
       "dependencies": {
         "begin": [ "end" ],
         "end": [ "begin" ],


### PR DESCRIPTION
To prevent typos like "pattern" instead of "patterns" or "capture" instead of "captures", additional properties shall be disallowed in the pattern definition.